### PR TITLE
Attribute2 in the yaml template fixed

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -143,7 +143,7 @@ Resources:
                                         "DataType": "String",
                                         "StringValue": "value of my attribute no 1"
                                     },
-                                    "Attr ibute2": {
+                                    "Attribute2": {
                                         "DataType": "String",
                                         "StringValue": "value of my attribute no 2"
                                     }


### PR DESCRIPTION
The name of Attribute2 had a blank space that would cause an error on execution (even if the sam validates ok)